### PR TITLE
Merge from Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # DQM: The Dark Prince - Monster tree generator
 
-A PowerShell utility that turns Game8's Dragon Quest Monsters 3 synthesis data into shareable Markdown. Feed it a monster name and it builds a mermaid-powered family tree, complete with portrait downloads, so you can visualize how to scout or fuse toward that monster.
+A PowerShell utility that turns Game8's Dragon Quest Monsters 3 synthesis data and MetalKid's field listings into shareable Markdown. Feed it a monster name and it builds a mermaid-powered family tree, complete with portraits, color-coded statuses, and scoutable location notes.
 
 ## Highlights
 
 - Pulls the official Game8 structural mapping dataset for Dark Prince monsters.
-- Scrapes each monster page for rank, family, number, and portrait imagery.
-- Builds a mermaid `graph LR` diagram describing every parent combination leading to the requested monster.
-- Writes a ready-to-publish Markdown file alongside an `images/` folder of cached artwork.
-- Caches third-party packages and JSON data locally for faster repeat runs.
+- Scrapes each monster page for number, family, rank, talents, and portrait imagery.
+- Cross-references MetalKid's lookup/locations API to flag scoutable monsters and list their known spawn spots.
+- Builds a mermaid `graph LR` diagram with color-coded nodes for the target monster, scoutable parents, duplicates, and embedded 96x96 artwork.
+- Writes a ready-to-publish Markdown file alongside an `images/` folder of cached artwork and family crests, while caching third-party packages and JSON data locally for fast repeat runs.
 
 ## Example Output
 
@@ -17,7 +17,7 @@ A PowerShell utility that turns Game8's Dragon Quest Monsters 3 synthesis data i
 ## Prerequisites
 
 - PowerShell 7+ (Windows PowerShell 5.1 also works but 7+ is recommended).
-- Internet access to reach Game8 and NuGet (the script downloads HtmlAgilityPack on first run).
+- Internet access to reach Game8, dev.metalkid.info, and NuGet (the script downloads HtmlAgilityPack on first run).
 - Permission to create `.cache/` and `images/` directories under the chosen output path.
 - Visual Studio Code is recommended for previewing Markdown. Install the `Markdown Preview Mermaid Support` extension to display Mermaid diagrams correctly.
 
@@ -29,6 +29,8 @@ Run the script from the repository root (or anywhere you have the `.ps1` file):
 pwsh .\Dqm3-GenerateMonsterTree.ps1 -MonsterName "Slime Knight" -OutputDirectory .\output -Overwrite
 ```
 
+The generated Markdown includes a synthesis graph and a `Scout locations` section populated from MetalKid data whenever the parents are scoutable.
+
 ### Parameters
 
 - `-MonsterName` *(required)*: Exact monster name as listed on Game8.
@@ -37,21 +39,23 @@ pwsh .\Dqm3-GenerateMonsterTree.ps1 -MonsterName "Slime Knight" -OutputDirectory
 
 ### What you get
 
-- `<OutputDirectory>/<monster-name>.md` with monster metadata and a mermaid synthesis tree.
-- `<OutputDirectory>/images/` containing portrait JPGs for every monster in the tree.
-- `.cache/` beside the script storing the HtmlAgilityPack package and the downloaded mapping JSON (deleted automatically on refresh).
+- `<OutputDirectory>/<monster-name>.md` containing monster metadata, a color-coded mermaid synthesis tree, and scout location bullet lists.
+- `<OutputDirectory>/images/` with 96x96 portrait JPGs plus any bundled family crests from `assets/images` (copied over on each run).
+- `.cache/` beside the script storing HtmlAgilityPack, the Game8 mapping JSON, and MetalKid lookup/location caches (deleted automatically when refreshed).
 
 ## Tips
 
 - Monster names must match Game8's capitalization and punctuation. If the script cannot locate the monster, verify the spelling on their site.
-- Delete `.cache/dqm3_mapping.json` to force a fresh download of the mapping dataset on the next run.
+- Delete `.cache/dqm3_mapping.json` to force a fresh download of the Game8 mapping dataset on the next run.
+- Delete `.cache/metalkid_locations.json` or `.cache/metalkid_monsters.json` to refresh scout location data if MetalKid updates their listings.
 - Mermaid diagrams render natively on platforms like GitHub and GitLab; other viewers may need a Mermaid plugin.
 
 ## Credits
 
 - Script vibe-coded by Codex.
-- Special thanks to [Game8.co](https://game8.co/games/DQM-Dark-Prince)
-- HtmlAgilityPack project for the HTML parser
+- Special thanks to [Game8.co](https://game8.co/games/DQM-Dark-Prince).
+- [MetalKid](https://dev.metalkid.info/) for the DQM3 location and lookup APIs.
+- HtmlAgilityPack project for the HTML parser.
 
 ## License
 


### PR DESCRIPTION
This pull request adds major new functionality to the monster tree generator by integrating MetalKid's monster location data, enhancing the output with scoutable monster detection, location listings, and improved color-coded diagrams. The changes also update the documentation to reflect these new features and clarify usage.

**Integration of MetalKid location data and scoutability:**

* Added functions (`Convert-JsAssignmentToJson`, `Get-MetalKidJsonPayload`, `Get-MetalKidLocationsDataset`, `Get-MetalKidMonsterLocations`) to fetch, cache, and parse MetalKid's monster location and lookup APIs, enabling cross-referencing of monsters with their known field locations.
* Implemented `Test-MonsterCanScout` and related logic to detect if a monster is scoutable based on mapping and MetalKid data. [[1]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bR383-R501) [[2]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bR545) [[3]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bR554-R557)
* Added `Get-ScoutEntries` to aggregate scoutable monsters and their locations for Markdown output. [[1]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bR383-R501) [[2]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bR837)

**Enhancements to Markdown and diagram output:**

* Updated the Markdown output to include a new "Scout locations" section, listing each scoutable monster in the synthesis tree and their known spawn locations or a fallback if unavailable.
* Modified the mermaid diagram generation to color-code nodes for scoutable monsters, duplicates, and the target monster, improving visual clarity. [[1]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bR730) [[2]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bR747-R780) [[3]](diffhunk://#diff-df6300cabf6ec6b026d424d337c28aacbd701200a42b8be4357bed4c0e16479bL484-R803)

**Documentation updates:**

* Revised `README.md` to document the new MetalKid integration, updated output format, additional cache files, and tips for refreshing data. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R33) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R58)

These changes significantly improve the usefulness of the generated Markdown by providing actionable field location data for scoutable monsters and making the synthesis trees easier to interpret at a glance.